### PR TITLE
Added motionIndex to onChange callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "build": "vite build",
     "build:static": "node ./generateStatic.js",
-    "dev": "vite"
+    "dev": "vite",
+    "prepare": "vite build"
   },
   "peerDependencies": {
     "framer-motion": "^5.0.0",

--- a/src/PietileCarousel.tsx
+++ b/src/PietileCarousel.tsx
@@ -24,7 +24,7 @@ interface Props {
   draggable?: boolean;
   margin?: number;
   style?: React.CSSProperties;
-  onChange?: (index: number) => void;
+  onChange?: (index: number, motionIndex: number) => void;
 }
 
 export const PietileCarousel = React.forwardRef<PietileCarouselHandle, Props>(

--- a/src/useOnChange.ts
+++ b/src/useOnChange.ts
@@ -5,7 +5,7 @@ import { MotionValue } from 'framer-motion';
 interface Config {
   childrenCount: number;
   index: MotionValue<number>;
-  onChange?: (index: number) => void;
+  onChange?: (index: number, motionIndex: number) => void;
 }
 
 export function useOnChange({ childrenCount, index, onChange }: Config): void {
@@ -24,7 +24,7 @@ export function useOnChange({ childrenCount, index, onChange }: Config): void {
 
       prevIndex = newIndex;
 
-      onChange(newIndex);
+      onChange(newIndex, Math.round(value));
     });
 
     return () => {


### PR DESCRIPTION
**Added prepare script to build on demand during installation phase**
This script should help to add building process on dependencies installation phase instead of having separate build stage.

**Added motionIndex to onChange callback to avoid slideTo misalignment**
There is an issue related to `goToSlide` function that works with index attached to motion instead of slide indexes. As the result the multiple scrolling presents. In this change, a new argument is added to the `onChange` callback. This argument present motion index value and with that developers could calculate the correct index for passing it to `goToSlide` function.
